### PR TITLE
Update sample-cl-rest-config.json

### DIFF
--- a/sample-cl-rest-config.json
+++ b/sample-cl-rest-config.json
@@ -1,5 +1,6 @@
 {
     "PORT": 3001,
+    "DOCPORT": 4001,
     "PROTOCOL": "https",
     "EXECMODE": "production"
 }


### PR DESCRIPTION
Missing DOCPORT line in config. c-lightning-REST won't start up unless this line is configured.