### PR TITLE
Update payInvoice error response structure

### DIFF
--- a/controllers/payments.js
+++ b/controllers/payments.js
@@ -114,7 +114,7 @@ exports.payInvoice = (req,res) => {
         res.status(201).json(data);
     }).catch(err => {
         global.logger.warn(err);
-        res.status(500).json(err);
+        res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
 }


### PR DESCRIPTION
The error response for the payInvoice endpoint is not consistent with all of the other endpoints. This PR just updates it to match all of the others.
