### PR TITLE
add funding_allocation_msat to listChannels response

### DIFF
--- a/controllers/channel.js
+++ b/controllers/channel.js
@@ -142,6 +142,11 @@ exports.openChannel = (req,res) => {
 *             spendable_msatoshi:
 *               type: string
 *               description: spendable_msatoshi
+*             funding_allocation_msat:
+*               type: object
+*               additionalProperties:
+*                 type: integer 
+*               description: funding_allocation_msat
 *             initiator:
 *               type: string
 *               description: Flag indicating if this peer initiated the channel (0,1)
@@ -175,7 +180,8 @@ exports.listChannels = (req,res) => {
                 msatoshi_total: peer.channels[0].msatoshi_total,
                 their_channel_reserve_satoshis: peer.channels[0].their_channel_reserve_satoshis,
                 our_channel_reserve_satoshis: peer.channels[0].our_channel_reserve_satoshis,
-                spendable_msatoshi: peer.channels[0].spendable_msatoshi
+                spendable_msatoshi: peer.channels[0].spendable_msatoshi,
+                funding_allocation_msat: peer.channels[0].funding_allocation_msat
             };
             if (peer.channels[0].direction === 0 || peer.channels[0].direction === 1) {
                 chanData.initiator = peer.channels[0].direction;


### PR DESCRIPTION
This is a follow-up on #25. The `initiator` (`direction`) field in the response turns out to not be very useful. After extensive testing with many networks & node configurations, the value returned from lightningd does not match the actual direction of the channel, even after factoring in the numeric ordering of the pubkeys.

I have figured out another way to get the direction which is more reliable. The `funding_allocation_msat` field contains a mapping of the two node pubkeys and their contribution to the funding transaction. 

Example:
```
[
  {
    "id": "024d8d1f9eac039a63be8beef4c71be00b1b51b82f20053a1d633be1f744c0e513",
    "connected": false,
    "state": "CHANNELD_NORMAL",
    "short_channel_id": "114x1x1",
    "channel_id": "a06e0119199ecae4c43128c54592d792f0b8ea78e42fd908edba08735c2f2234",
    "funding_txid": "35222f5c7308baed08d92fe478eab8f092d79245c52831c4e4ca9e1919016ea0",
    "private": false,
    "msatoshi_to_us": 100000000,
    "msatoshi_total": 250000000,
    "their_channel_reserve_satoshis": 2500,
    "our_channel_reserve_satoshis": 2500,
    "spendable_msatoshi": 97500000,
    "funding_allocation_msat": {
      "0263ee9128d07a119a393075c337838c03d9c7c49da809e36ce5a6f04f39b4bd2d": 0,
      "024d8d1f9eac039a63be8beef4c71be00b1b51b82f20053a1d633be1f744c0e513": 250000000
    },
    "initiator": 1,
    "alias": "bob"
  }
]
```

This essentially says that the node with pubkey `024...513` opened this channel because they contributed all of the msats to the funding transaction. This method won't be accurate if dual-funded channels become a thing, but it will suffice for now.

This PR just adds the `funding_allocation_msat` field to the API response, so my application can do whatever logic I need to determine the channel initiator.

You can remove the `initiator` field if you'd like to because I have not found it to be accurate in my testing.