### PR TITLE
Revert "switch to version tags without v"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout  
       - run:
           command: |
-            LATEST_TAG=${CIRCLE_TAG}
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
             if [ -z "$LATEST_TAG" ]
             then
                   LATEST_TAG="latest"
@@ -31,7 +31,7 @@ jobs:
       - run:
           command: |
             sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
-            LATEST_TAG=${CIRCLE_TAG}
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
             if [ -z "$LATEST_TAG" ]
             then
                   LATEST_TAG="latest"
@@ -70,7 +70,7 @@ jobs:
             #
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             #
-            LATEST_TAG=${CIRCLE_TAG}
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
             if [ -z "$LATEST_TAG" ]
             then
                   LATEST_TAG="latest"
@@ -93,19 +93,19 @@ workflows:
               only: master
             # only act on version tags
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*/
       - publish_docker_linuxarm32:
           filters:
             branches:
               only: master
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*/
       - publish_docker_linuxarm64:
           filters:
             branches:
               only: master
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*/
       - publish_docker_multiarch:
           requires:
             - publish_docker_linuxamd64
@@ -115,4 +115,4 @@ workflows:
             branches:
               only: master
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
Noticed that your versioning is actually done with a v prefix here. This follows that convention