### PR TITLE
add rpc endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ For running the server, rename the file `sample-cl-rest-config.json` to `cl-rest
 - DOCPORT (Default: `4001`) - Port for serving the swagger documentation
 - PROTOCOL (Default: `https`) - Two options are supported `https` and `http`(unencrypted and insecure communication between c-lightning and API server).
 - EXECMODE (Default: `production`) - Control for more detailed log info.
+- RPCCOMMANDS (Default: `[]`) - Enable additional RPC commands for `/rpc` endpoint
 
 #### Option 2: With the plugin configuration, if used as a plugin
-For running as a plugin, configure the options, `rest-port`, `rest-docport`, `rest-protocol` and `rest-execmode` in your c-lightning `config` file. Defaults are the same as in option # 1.
+For running as a plugin, configure the options, `rest-port`, `rest-docport`, `rest-protocol`, `rest-execmode` and `rest-rpc` in your c-lightning `config` file. Defaults are the same as in option # 1 with the exception that `rest-rpc` is a comma separated string.
 
 ### <a name="exec"></a>Execute Server
 You can choose from the below options to run the API server
@@ -172,5 +173,9 @@ If you need help converting your macaroon to hex format you can use the Node.js 
 - listnodes (/v1/network/listNode) - `GET`: Lookup node info from the network graph, for a given [pubkey]
 - listchannels (/v1/network/listChannel) - `GET`: Lookup channel info from the network graph, for a given [short_channel_id]
 - feerates (/v1/network/feeRates) - `GET`: Lookup fee rates on the network, for a given rate style (`perkb` or `perkw`)
+
+### RPC
+
+- rpc (/v1/rpc) - `POST`: additional access to RPC comands
 
 PRs are welcome! :-)

--- a/app.js
+++ b/app.js
@@ -44,5 +44,6 @@ app.use('/v1/channel', require('./routes/channel'));
 app.use('/v1/pay', require('./routes/payments'));
 app.use('/v1/invoice', require('./routes/invoice'));
 app.use('/v1/network', require('./routes/network'));
+app.use('/v1/rpc', require('./routes/rpc'));
 
 module.exports = app;

--- a/controllers/rpc.js
+++ b/controllers/rpc.js
@@ -1,0 +1,52 @@
+//This controller houses user enabled rpc functions
+
+//Function # 1
+//Invoke an RPC command to fetch the data for additional commands that do not have an endpoint and are enabled in the configuration
+//Arguments - varies per command
+/**
+* @swagger
+* /rpc:
+*   post:
+*     tags:
+*       - RPC
+*     name: rpc
+*     summary: Issue RPC commands that are enabled in user configuration
+*     consumes:
+*       - application/json
+*     responses:
+*       200:
+*         description: Information specific to the RPC command
+*       500:
+*         description: Server error
+*/exports.rpc = (req,res) => {
+  
+  global.logger.log('allowed rpc commnads: '+ global.config.RPCCOMMANDS);
+  const commands = global.config.RPCCOMMANDS;
+  
+  if (commands.length === 1 && !commands[0]) {
+    res.status(500).json({error: "Endpoint not enabled."});
+    return;
+  }
+
+  const allowAll = commands.length === 1 && commands[0] === "*";
+
+  if (!~commands.indexOf(req.body.method) && !allowAll) {
+    res.status(500).json({error: "Command not enabled."});
+    return;
+  }
+
+  function connFailed(err) { throw err }
+  ln.on('error', connFailed);
+
+  //Call the rpc command
+  ln.call(req.body.method, req.body.params).then(data => {
+      data.api_version = require('../package.json').version;
+      global.logger.log(data);
+      global.logger.log('rpc success');
+      res.status(200).json(data);
+  }).catch(err => {
+      global.logger.warn(err);
+      res.status(500).json({error: err});
+  });
+  ln.removeListener('error', connFailed);
+}

--- a/lightning-client-js.js
+++ b/lightning-client-js.js
@@ -112,6 +112,7 @@ class LightningClient extends EventEmitter {
 
         const callInt = ++this.reqcount;
         const sendObj = {
+            jsonrpc: "2.0",
             method,
             params: args,
             id: ''+callInt

--- a/plugin.js
+++ b/plugin.js
@@ -7,6 +7,7 @@ restPlugin.addOption('rest-port', 3001, 'rest plugin listens on this port', 'int
 restPlugin.addOption('rest-docport', 4001, 'rest plugin listens on this port', 'int');
 restPlugin.addOption('rest-protocol', 'https', 'rest plugin protocol', 'string');
 restPlugin.addOption('rest-execmode', 'production', 'rest exec mode', 'string');
+restPlugin.addOption('rest-rpc', ' ', 'allowed rpc commands', 'string');
 
 restPlugin.onInit = params => {
     process.env.LN_PATH = `${params.configuration['lightning-dir']}/${params.configuration['rpc-file']}`
@@ -16,6 +17,7 @@ restPlugin.onInit = params => {
         DOCPORT: params.options['rest-docport'],
         PROTOCOL: params.options['rest-protocol'],
         EXECMODE: params.options['rest-execmode'],
+        RPCCOMMANDS: params.options['rest-rpc'].trim().split(",").map(s => s.trim()),
         PLUGIN: restPlugin
     }
 

--- a/routes/rpc.js
+++ b/routes/rpc.js
@@ -1,0 +1,8 @@
+var router = require('express').Router();
+var rpcController = require('../controllers/rpc');
+var tasteMacaroon = require('../utils/tasteMacaroon');
+
+//Get the basic information from the node
+router.post('/', tasteMacaroon, rpcController.rpc);
+
+module.exports  = router;

--- a/sample-cl-rest-config.json
+++ b/sample-cl-rest-config.json
@@ -2,5 +2,6 @@
     "PORT": 3001,
     "DOCPORT": 4001,
     "PROTOCOL": "https",
-    "EXECMODE": "production"
+    "EXECMODE": "production",
+    "RPCCOMMANDS": []
 }


### PR DESCRIPTION
This adds an additional `/rpc` endpoint where users can post in RPC format.  c-lightning allows adding additional RPC commands via plugins.  This would give developers the ability to build on top of plugins.

By default, it is disabled and completely opt-in.  Users can enable by adding acceptable commands in the configuration, or enable all commands with `*` wildcard