### PR TITLE
Fix: The docker container couldn't be restarted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,17 @@
-# Auto detect text files and perform LF normalization
+# Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12-alpine
 WORKDIR /usr/src/app
 COPY . .
-RUN apk add --update openssl && \
+RUN apk add --update openssl tini && \
     rm -rf /var/cache/apk/*
 RUN npm install --only=production
 
@@ -14,4 +14,4 @@ EXPOSE 3001
 EXPOSE 4001
 
 RUN chmod +x docker-entrypoint.sh
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "./docker-entrypoint.sh"]

--- a/arm32v7.Dockerfile
+++ b/arm32v7.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100 AS builder
+FROM debian:bullseye-slim AS builder
 RUN apt-get update \
 	&& apt-get install -qq --no-install-recommends qemu qemu-user-static qemu-user binfmt-support
 
@@ -6,7 +6,7 @@ FROM arm32v7/node:12-alpine
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 WORKDIR /usr/src/app
 COPY . .
-RUN apk add --update openssl && \
+RUN apk add --update openssl tini && \
     rm -rf /var/cache/apk/*
 RUN npm install --only=production
 
@@ -19,4 +19,4 @@ EXPOSE 3001
 EXPOSE 4001
 
 RUN chmod +x docker-entrypoint.sh
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "./docker-entrypoint.sh"]

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu as builder
+FROM debian:bullseye-slim as builder
 RUN apt-get update \
 	&& apt-get install -qq --no-install-recommends qemu qemu-user-static qemu-user binfmt-support
 
@@ -6,7 +6,7 @@ FROM arm64v8/node:12-alpine
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 WORKDIR /usr/src/app
 COPY . .
-RUN apk add --update openssl && \
+RUN apk add --update openssl tini && \
     rm -rf /var/cache/apk/*
 RUN npm install --only=production
 
@@ -19,4 +19,4 @@ EXPOSE 3001
 EXPOSE 4001
 
 RUN chmod +x docker-entrypoint.sh
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,4 +17,4 @@ if [[ "${LIGHTNINGD_READY_FILE}" ]]; then
     echo "The chain is fully synched"
 fi
 
-node cl-rest.js
+exec node cl-rest.js


### PR DESCRIPTION
This PR:

1. Fix the `.gitattributes`, without which cloning this repo and building a docker image will result in shell files with CRLF on windows, and thus, not working properly
2. Use `tini` to run the docker-entrypoint. (Long story short, without it, the container may end up in a stale state because it can't restart)
3. Use `exec` to run node. This is just an optimization, because the `bash` not necessary anymore.
4. Fix version of the images used to build, so we are sure the build doesn't suddenly break.
5. Use `debian-slim` rather than `ubuntu` because this is smaller image.

Can you make new docker image with it? A btcpayserver user got into the stale restart situation, and I was attempting to help him over it.