### PR TITLE
Update coverage docs

### DIFF
--- a/docs/CLTCommandCoverage.md
+++ b/docs/CLTCommandCoverage.md
@@ -17,11 +17,11 @@
 
 === channels ===
 - [x] close
-- [ ] fundchannel
+- [x] fundchannel (as channel/openChannel)
 - [ ] fundchannel_cancel
 - [ ] fundchannel_complete
 - [ ] fundchannel_start
-- [ ] funderupdate (experimental-dual-fund required)
+- [x] funderupdate (experimental-dual-fund required)
 - [x] getroute
 - [x] listchannels
 - [x] listforwards
@@ -35,9 +35,9 @@
 - [x] setchannelfee
 
 === datastore ===
-- [ ] datastore
-- [ ] deldatastore
-- [ ] listdatastore
+- [x] datastore
+- [x] deldatastore
+- [x] listdatastore
 
 === network ===
 - [ ] addgossip
@@ -52,29 +52,29 @@
 - [ ] sendonionmessage
 
 === offers (experimental-offers required) ===
-- [ ] disableoffer
-- [ ] fetchinvoice
-- [ ] listoffers
-- [ ] offer
+- [x] disableoffer
+- [x] fetchinvoice
+- [x] listoffers
+- [x] offer
 - [ ] offerout
 - [ ] sendinvoice
 
 === payment ===
 - [ ] createinvoice
 - [ ] createonion
-- [ ] decode
+- [x] decode
 - [x] decodepay
 - [x] delexpiredinvoice
 - [x] delinvoice
 - [ ] delpay
 - [x] invoice
 - [x] listinvoices
-- [x] listsendpays
+- [x] listsendpays (as pay/listPayments)
 - [ ] listtransactions
 - [ ] sendonion
 - [ ] sendpay
 - [ ] waitanyinvoice
-- [ ] waitinvoice
+- [x] waitinvoice
 - [ ] waitsendpay
 
 === plugin ===
@@ -99,13 +99,16 @@
 - [ ] getlog
 - [ ] getsharedsecret
 - [ ] help
-- [ ] listconfigs
+- [x] listconfigs
 - [x] listfunds
 - [ ] notifications
 - [ ] parsefeerate
 - [x] signmessage
 - [ ] stop
 - [ ] waitblockheight
+
+=== custom ===
+- [x] user-enabled RPC commands via /rpc
 
 === developer (developer mode required) ===   
 - [ ] dev-listaddrs

--- a/docs/CLTCommandCoverage.md
+++ b/docs/CLTCommandCoverage.md
@@ -48,10 +48,10 @@
 - [ ] ping
 - [ ] sendcustommsg
 
-=== onions (experimental-onion-messages flag required) ===
+=== onions (experimental-onion-messages required) ===
 - [ ] sendonionmessage
 
-=== offers (experimental-offers flag required) ===
+=== offers (experimental-offers required) ===
 - [ ] disableoffer
 - [ ] fetchinvoice
 - [ ] listoffers
@@ -107,6 +107,6 @@
 - [ ] stop
 - [ ] waitblockheight
 
-=== developer ===   
+=== developer (developer mode required) ===   
 - [ ] dev-listaddrs
 - [ ] dev-rescan-outputs

--- a/docs/CLTCommandCoverage.md
+++ b/docs/CLTCommandCoverage.md
@@ -3,6 +3,7 @@
 === bitcoin ===
 - [x] feerates
 - [ ] fundpsbt
+- [ ] multiwithdraw
 - [x] newaddr
 - [ ] reserveinputs
 - [ ] sendpsbt
@@ -11,30 +12,61 @@
 - [ ] txprepare
 - [ ] txsend
 - [ ] unreserveinputs
+- [ ] utxopsbt
 - [x] withdraw
 
 === channels ===
 - [x] close
+- [ ] fundchannel
 - [ ] fundchannel_cancel
 - [ ] fundchannel_complete
 - [ ] fundchannel_start
+- [ ] funderupdate (experimental-dual-fund required)
 - [x] getroute
 - [x] listchannels
 - [x] listforwards
+- [ ] multifundchannel
+- [ ] openchannel_abort
+- [ ] openchannel_bump
+- [ ] openchannel_init
+- [ ] openchannel_signed
+- [ ] openchannel_update
+- [ ] setchannel
 - [x] setchannelfee
 
+=== datastore ===
+- [ ] datastore
+- [ ] deldatastore
+- [ ] listdatastore
+
 === network ===
+- [ ] addgossip
 - [x] connect
 - [x] disconnect
 - [x] listnodes
 - [x] listpeers
 - [ ] ping
+- [ ] sendcustommsg
+
+=== onions (experimental-onion-messages flag required) ===
+- [ ] sendonionmessage
+
+=== offers (experimental-offers flag required) ===
+- [ ] disableoffer
+- [ ] fetchinvoice
+- [ ] listoffers
+- [ ] offer
+- [ ] offerout
+- [ ] sendinvoice
 
 === payment ===
+- [ ] createinvoice
 - [ ] createonion
+- [ ] decode
 - [x] decodepay
 - [x] delexpiredinvoice
 - [x] delinvoice
+- [ ] delpay
 - [x] invoice
 - [x] listinvoices
 - [x] listsendpays
@@ -69,6 +101,8 @@
 - [ ] help
 - [ ] listconfigs
 - [x] listfunds
+- [ ] notifications
+- [ ] parsefeerate
 - [x] signmessage
 - [ ] stop
 - [ ] waitblockheight


### PR DESCRIPTION
I really like the checklist showing methods already covered by c-lightning-REST, so I updated it with the current range of API methods available & current coverage in this repo. There may be room for improvement in categorization.

References: [c-lightning documentation page](https://lightning.readthedocs.io/index.html)

Reviewing this list, I plan to implement a few of these methods in a later pull request.