### PR TITLE
trim rest-domain to remove space if null

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -23,7 +23,7 @@ restPlugin.onInit = params => {
         EXECMODE: params.options['rest-execmode'],
         RPCCOMMANDS: params.options['rest-rpc'].trim().split(",").map(s => s.trim()),
         LNRPCPATH: params.options['rest-lnrpcpath'],
-        DOMAIN: params.options['rest-domain'],
+        DOMAIN: params.options['rest-domain'].trim(),
         PLUGIN: restPlugin
     }
 


### PR DESCRIPTION
This fixes a problem where the [`DOMAIN` config param](https://github.com/Ride-The-Lightning/c-lightning-REST/blob/bb23531b35f8ba827c924fec6932f7977c3ef385/plugin.js#L14) is a single space char instead of null, which mysteriously breaks [my docker build](https://github.com/Start9Labs/c-lightning-wrapper/blob/9f8dcd3092bf1e59e4f57e502dcd66f52aa0420e/Dockerfile), causing a runtime error on [this line](https://github.com/Ride-The-Lightning/c-lightning-REST/blob/bb23531b35f8ba827c924fec6932f7977c3ef385/cl-rest.js#L49):

```
Error Loading command line extensions
548493957616:error:2206D06D:X509 V3 routines:X509V3_parse_list:invalid null value:../crypto/x509v3/v3_utl.c:378:
548493957616:error:22097069:X509 V3 routines:do_ext_nconf:invalid extension string:../crypto/x509v3/v3_conf.c:92:name=subjectAltName,section=DNS:
548493957616:error:22098080:X509 V3 routines:X509V3_EXT_nconf:error in extension:../crypto/x509v3/v3_conf.c:47:name=subjectAltName, value=DNS:
node:fs:594
  handleErrorFromBinding(ctx);
  ^
```

The reason I say "mysterious" is because [this line](https://github.com/Ride-The-Lightning/c-lightning-REST/blob/bb23531b35f8ba827c924fec6932f7977c3ef385/cl-rest.js#L32) apparently works just fine and stores `localhost` into the `DOMAIN` constant, but only before [this commit hash](https://github.com/Ride-The-Lightning/c-lightning-REST/tree/718a1fe00655f7f6b5d4e094d1adaf46c5bc3309). After this commit, the line that says `const DOMAIN = config.DOMAIN || "localhost";` stops working properly, and instead saves a single blank space (`' '`) into `DOMAIN`, causing the above `openssl` error.  I cannot, for the life of me, figure out why the commit hash listed could have altered this basic javascript functionality. When testing the "broken" commit and the commit immediately before, I did not change anything about the build, other than checking out the next/previous commit, and yet the problem was 100% predictably reproducible.

Apparently the `clightningjs` module requires config params to be non-empty, because it threw an error when I made it an empty string:

```
 /usr/local/libexec/c-lightning/plugins/c-lightning-REST/node_modules/clightningjs/src/plugin.js:132
       throw new Error('You need to pass at least a name, default value and description for the option');
       ^
 
 Error: You need to pass at least a name, default value and description for the option
     at Plugin.addOption (/usr/local/libexec/c-lightning/plugins/c-lightning-REST/node_modules/clightningjs/src/plugin.js:132:13)
     at Object.<anonymous> (/usr/local/libexec/c-lightning/plugins/c-lightning-REST/plugin.js:14:12)
     at Module._compile (node:internal/modules/cjs/loader:1126:14)
     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
     at Module.load (node:internal/modules/cjs/loader:1004:32)
     at Function.Module._load (node:internal/modules/cjs/loader:839:12)
     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
     at node:internal/main/run_main_module:17:47
 2022-08-23T16:43:44.790Z INFO    plugin-plugin.js: Killing plugin: exited before replying to getmanifest
```

So I opted instead to add a `.trim()` to [this line](https://github.com/Ride-The-Lightning/c-lightning-REST/blob/bb23531b35f8ba827c924fec6932f7977c3ef385/plugin.js#L26). This makes both `clightningjs` and `openssl` happy.

Note: just guessing, but [this line](https://github.com/Ride-The-Lightning/c-lightning-REST/blob/bb23531b35f8ba827c924fec6932f7977c3ef385/plugin.js#L25) may also benefit from a `.trim()`, since it is also stored as a single blank space.