### PR TITLE
Allow specifying the binding address

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For running the server, rename the file `sample-cl-rest-config.json` to `cl-rest
 - LNRPCPATH (Default: ` `)
 - RPCCOMMANDS (Default: `["*"]`)
 - DOMAIN (Default: `localhost`)
+- BIND (Default: `::`)
 
 #### Option 2: With the plugin configuration, if used as a plugin
 If running as a plugin, configure the below options in your c-lightning `config` file:
@@ -56,6 +57,7 @@ If running as a plugin, configure the below options in your c-lightning `config`
 - `rest-lnrpcpath`
 - `rest-rpc`
 - `rest-domain`
+- `rest-bind`
 
 Defaults are the same as in option # 1 with the exception that `rest-rpc` is a comma separated string.
 

--- a/cl-rest.js
+++ b/cl-rest.js
@@ -30,6 +30,7 @@ const PORT = config.PORT;
 const EXECMODE = config.EXECMODE;
 const DOCPORT = config.DOCPORT;
 const DOMAIN = config.DOMAIN || "localhost";
+const BIND = config.BIND || "::";
 
 //Create certs folder
 try {
@@ -134,13 +135,13 @@ try {
 docserver = require( 'http' ).createServer( docapp );
 
 //Start the server
-server.listen(PORT, function() {
-    global.logger.warn('--- cl-rest api server is ready and listening on port: ' + PORT + ' ---');
+server.listen(PORT, BIND, function() {
+    global.logger.warn('--- cl-rest api server is ready and listening on ' + BIND + ':' + PORT + ' ---');
 })
 
 //Start the docserver
-docserver.listen(DOCPORT, function() {
-    global.logger.warn('--- cl-rest doc server is ready and listening on port: ' + DOCPORT + ' ---');
+docserver.listen(DOCPORT, BIND, function() {
+    global.logger.warn('--- cl-rest doc server is ready and listening on ' + BIND + ':' + PORT + ' ---');
 })
 
 exports.closeServer = function(){

--- a/plugin.js
+++ b/plugin.js
@@ -12,6 +12,7 @@ restPlugin.addOption('rest-execmode', 'production', 'rest exec mode', 'string');
 restPlugin.addOption('rest-rpc', ' ', 'allowed rpc commands', 'string');
 restPlugin.addOption('rest-lnrpcpath', ' ', 'path for lightning-rpc', 'string');
 restPlugin.addOption('rest-domain', ' ', 'domain name for self-signed cert', 'string');
+restPlugin.addOption('rest-bind', ' ', 'Binding address', 'string');
 
 restPlugin.onInit = params => {
     process.env.LN_PATH = `${params.configuration['lightning-dir']}/${params.configuration['rpc-file']}`
@@ -24,6 +25,7 @@ restPlugin.onInit = params => {
         RPCCOMMANDS: params.options['rest-rpc'].trim().split(",").map(s => s.trim()),
         LNRPCPATH: params.options['rest-lnrpcpath'],
         DOMAIN: params.options['rest-domain'].trim(),
+        BIND: params.options['rest-bind'].trim(),
         PLUGIN: restPlugin
     }
 

--- a/sample-cl-rest-config.json
+++ b/sample-cl-rest-config.json
@@ -4,5 +4,6 @@
     "PROTOCOL": "https",
     "EXECMODE": "production",
     "RPCCOMMANDS": ["*"],
-    "DOMAIN": "localhost"
+    "DOMAIN": "localhost",
+    "BIND": "::"
 }


### PR DESCRIPTION
This PR introduces a new option `BIND` to select the API binding address.

Its default value (`::`) makes it backwards compatible: https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback
```
If host is omitted, the server will accept connections on the unspecified IPv6 address (::)
when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.

In most operating systems, listening to the unspecified IPv6 address (::) may cause the
net.Server to also listen on the unspecified IPv4 address (0.0.0.0).
```
Fixes #84