### PR TITLE
Return all `peer` data in `listpeers`

### DIFF
--- a/controllers/peers.js
+++ b/controllers/peers.js
@@ -92,13 +92,7 @@ exports.listPeers = (req,res) => {
     ln.listpeers().then(data => {
         Promise.all(
             data.peers.map(peer => {
-                peerData = {};
-                peerData = {
-                    id: peer.id,
-                    connected: peer.connected,
-                    netaddr: peer.netaddr
-                };
-                return getAliasForPeer(peerData);
+                return getAliasForPeer(peer);
             })
         ).then(function(peerList) {
             res.status(200).json(peerList);


### PR DESCRIPTION
I don't understand why are you filtering the data the `peer` object, but there is a lot of useful data return by this endpoint that shouldn't be filtered.