### PR TITLE
Feature: Support IPs and multiple Subject Alt Names in the TLS certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The below run time configuration are available, which can be configured either v
 - Lightning-RPC Path - Configure the path where `lightning-rpc` file is located. It will default to standard lightning path if not configured
 - RPC Command -  - Enable additional RPC commands for `/rpc` endpoint
 - Domain - An external domain to be used for the self-signed certificate
+- IP - A static IP to be used for the self-signed certificate
 
 #### Option 1: Via Config file `cl-rest-config.json`
 For running the server, rename the file `sample-cl-rest-config.json` to `cl-rest-config.json`. Following parameters can be configured in the config file:
@@ -46,6 +47,7 @@ For running the server, rename the file `sample-cl-rest-config.json` to `cl-rest
 - LNRPCPATH (Default: ` `)
 - RPCCOMMANDS (Default: `["*"]`)
 - DOMAIN (Default: `localhost`)
+- IP (Default: `127.0.0.1`)
 - BIND (Default: `::`)
 
 #### Option 2: With the plugin configuration, if used as a plugin
@@ -60,6 +62,7 @@ If running as a plugin, configure the below options in your core lightning `conf
 - `rest-lnrpcpath`
 - `rest-rpc`
 - `rest-domain`
+- `rest-ip`
 - `rest-bind`
 
 Defaults are the same as in option # 1 with the exception that `rest-rpc` is a comma separated string.
@@ -129,6 +132,10 @@ With the default config, APIs will be served over `https` (a self signed certifi
 Sample url: `https://localhost:3001/v1/getinfo/`
 
 Providing a `DOMAIN` to the c-lightning-REST configuration will add the domain as a `subjectAltName` to the openssl certificate, permitting successful certificate validation by users and applications, e.g. Zeus, when connecting to the server at via that domain.
+The same thing can be achieved with the `IP` configuration parameter, but for a static IP instead of a DNS domain.
+
+Additionally, both `DOMAIN` and `IP` support specifying multiple comma-separated values, for instance `localhost,example.com,ln.example.com`, or `127.0.0.1,4.5.6.7`.
+The resulting TLS certificate will be able to validate HTTPS responses received from any of these domains and IPs.
 
 If you are *upgrading* a server which is already configured, you should first backup and your entire `./certs` directory in case you need to restore it later.
 Following this you should delete *only* the `.certs/certificate.pem` and `.certs/key.pem` files, so that new SSL certificates can be generated which take the `subjectAltName` into consideration.

--- a/cl-rest.js
+++ b/cl-rest.js
@@ -30,6 +30,7 @@ const PORT = config.PORT;
 const EXECMODE = config.EXECMODE;
 const DOCPORT = config.DOCPORT;
 const DOMAIN = config.DOMAIN || "localhost";
+const IP = config.IP || "127.0.0.1";
 
 // Check if any interface on the device has an IPv6 address
 const os = require('os');
@@ -62,9 +63,12 @@ try {
 if ( ! fs.existsSync( key ) || ! fs.existsSync( certificate ) ) {
     global.logger.log("Generating SSL cert and key");
     try {
+        let subjectAltNames = DOMAIN.split(',').map((domain) => `DNS:${ domain }`).join(',');
+        subjectAltNames += ',' + IP.split(',').map((ip) => `IP:${ ip }`).join(',');
+
         execSync( 'openssl version', execOptions );
         execSync(
-            `openssl req -x509 -newkey rsa:2048 -keyout ./certs/key.tmp.pem -out ${ certificate } -days 365 -nodes -subj "/C=US/ST=Foo/L=Bar/O=Baz/CN=c-lightning-rest" -addext "subjectAltName = DNS:${ DOMAIN }"`,
+            `openssl req -x509 -newkey rsa:2048 -keyout ./certs/key.tmp.pem -out ${ certificate } -days 365 -nodes -subj "/C=US/ST=Foo/L=Bar/O=Baz/CN=c-lightning-rest" -addext "subjectAltName = ${ subjectAltNames }"`,
             execOptions
         );
         execSync( `openssl rsa -in ./certs/key.tmp.pem -out ${ key }`, execOptions );

--- a/clrest.js
+++ b/clrest.js
@@ -12,6 +12,7 @@ restPlugin.addOption('rest-execmode', 'production', 'rest exec mode', 'string');
 restPlugin.addOption('rest-rpc', ' ', 'allowed rpc commands', 'string');
 restPlugin.addOption('rest-lnrpcpath', ' ', 'path for lightning-rpc', 'string');
 restPlugin.addOption('rest-domain', ' ', 'domain name for self-signed cert', 'string');
+restPlugin.addOption('rest-ip', ' ', 'IP for self-signed cert', 'string');
 restPlugin.addOption('rest-bind', ' ', 'Binding address', 'string');
 
 restPlugin.onInit = params => {
@@ -25,6 +26,7 @@ restPlugin.onInit = params => {
         RPCCOMMANDS: params.options['rest-rpc'].trim().split(",").map(s => s.trim()),
         LNRPCPATH: params.options['rest-lnrpcpath'],
         DOMAIN: params.options['rest-domain'].trim(),
+        IP: params.options['rest-ip'].trim(),
         BIND: params.options['rest-bind'].trim(),
         PLUGIN: restPlugin
     }

--- a/sample-cl-rest-config.json
+++ b/sample-cl-rest-config.json
@@ -5,5 +5,6 @@
     "EXECMODE": "production",
     "RPCCOMMANDS": ["*"],
     "DOMAIN": "localhost",
+    "IP": "127.0.0.1",
     "BIND": "::"
 }


### PR DESCRIPTION
The current `DOMAIN` option is a bit too restrictive, as it only allows registering one Subject Alt Name on the self-signed TLS certificate, and it must be a DNS domain. When c-lightning-REST is hosted on a machine without an associated domain these certificates cannot be used to validate the responses.

The new `IP` configuration option allows setting an static IP as Subject Alt Name. Its default value is `127.0.0.1`, which is backwards compatible.

Additionally, I've tweaked both options to allow multiple comma-separated values, as the openssl tool also supports multiple SANs.


## Examples

`openssl x509 -in certs/certificate.pem -text -noout` has been used to decode these certificates.

### master branch, default DOMAIN:

```
...
X509v3 Subject Alternative Name:
    DNS:localhost
```

### Multi SAN PR, default DOMAIN and IP:

```
...
X509v3 Subject Alternative Name: 
    DNS:localhost, IP Address:127.0.0.1
```

### Multi SAN PR, custom DOMAIN and IP:

DOMAIN: `localhost,example.com,ln.example.com`
IP: `127.0.0.1,1.2.3.4`

```
...
X509v3 Subject Alternative Name: 
    DNS:localhost, DNS:example.com, DNS:ln.example.com, IP Address:127.0.0.1, IP Address:1.2.3.4
```