### PR TITLE
Fixed npm start on default shell (debian)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "c-lightning REST API suite",
   "main": "cl-rest.js",
   "scripts": {
-    "start": "SET NODE_ENV=dev && node cl-rest.js",
+    "start": "set NODE_ENV=dev && node cl-rest.js",
     "watch": "NODE_ENV=development nodemon cl-rest.js",
     "test": "mocha --exit"
   },


### PR DESCRIPTION
I have renamed `SET` to `set` in the `package.json`-file.

I'm an ubuntu user and the `npm start` script doesn't work for me. It yields the following error.

```
> c-lightning-rest@0.10.5 start
> SET NODE_ENV=dev && node cl-rest.js

sh: 1: SET: not found
```